### PR TITLE
Fix Playwright container version mismatch for #86

### DIFF
--- a/.github/workflows/daily-playwright.yml
+++ b/.github/workflows/daily-playwright.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
       - name: Repo auschecken
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       # Bleibt enthalten, damit garantiert Node.js 24 verwendet wird
       # und der npm-Cache über GitHub Actions verfügbar ist.
@@ -157,7 +157,7 @@ jobs:
 
       - name: Fehlgeschlagene Screenshots hochladen
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-failed-files
           path: failed-playwright-files

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,33 +12,24 @@
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.37.1"
+        "@playwright/test": "1.62.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
-      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.37.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+        "node": ">=20"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "20.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.4.tgz",
-      "integrity": "sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==",
-      "dev": true
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -57,6 +48,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -65,36 +57,48 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
-      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       }
     }
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.37.1.tgz",
-      "integrity": "sha512-bq9zTli3vWJo8S3LwB91U0qDNQDpEXnw7knhxLM0nwDvexQAwx9tO8iKDZSqqneVq+URd/WIoz+BALMqUTgdSg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "fsevents": "2.3.2",
-        "playwright-core": "1.37.1"
+        "playwright": "1.62.0"
       }
-    },
-    "@types/node": {
-      "version": "20.5.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.4.tgz",
-      "integrity": "sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==",
-      "dev": true
     },
     "dotenv": {
       "version": "16.3.1",
@@ -108,10 +112,20 @@
       "dev": true,
       "optional": true
     },
+    "playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.62.0"
+      }
+    },
     "playwright-core": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.37.1.tgz",
-      "integrity": "sha512-17EuQxlSIYCmEMwzMqusJ2ztDgJePjrbttaefgdsiqeLWidjYz9BxXaTaZWxH1J95SHGk6tjE+dwgWILJoUZfA==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://github.com/BEXIS2/bexis2-core-ui-tests#readme",
   "devDependencies": {
-    "@playwright/test": "^1.37.1"
+    "@playwright/test": "1.62.0"
   },
   "dependencies": {
     "dotenv": "^16.3.1"


### PR DESCRIPTION
## Zusammenfassung

Dieser PR repariert die mit Issue #86 eingeführte Docker-Ausführung des täglichen Playwright-Workflows.

Der Workflow verwendet das Image `mcr.microsoft.com/playwright:v1.62.0-noble` und prüft ausdrücklich, ob im Repository dieselbe Playwright-Version installiert ist. `package.json` und `package-lock.json` waren jedoch weiterhin auf Playwright 1.37.1 festgelegt. Dadurch brach der Workflow beim Versionscheck ab, bevor ein einziger Test ausgeführt wurde.

## Änderungen

- `@playwright/test` exakt auf `1.62.0` gesetzt.
- `package-lock.json` vollständig auf Playwright, Playwright Core und die Browserpakete der Version `1.62.0` aktualisiert.
- Docker-Image und npm-Abhängigkeit damit versionsgleich gemacht.
- `actions/checkout` von `v5` auf `v6` aktualisiert.
- `actions/upload-artifact` von `v4` auf `v6` aktualisiert.
- Die beiden offiziellen Actions laufen dadurch auf der aktuellen Node.js-24-Action-Runtime und passen zum bereits verwendeten `actions/setup-node@v6`.

## Auswirkung

- `npm ci` installiert reproduzierbar genau die zum Container gehörende Playwright-Version.
- Der Schritt `Playwright-Version prüfen` passiert nun erfolgreich.
- Die im Docker-Image enthaltenen Browser und Systemabhängigkeiten können ohne zusätzlichen `playwright install --with-deps`-Download verwendet werden.
- Der Workflow erreicht wieder den eigentlichen Playwright-Testschritt.

## Verifikation

- `npm ci --prefer-offline --no-audit --fund=false` erfolgreich.
- Installierte Playwright-Version: `1.62.0`.
- `playwright test --list` erfolgreich: 259 Tests in 16 Dateien erkannt.
- `actionlint 1.7.12` ohne Befund.
- `git diff --check` ohne Fehler.

Die vollständigen E2E-Tests benötigen die GitHub-Secrets und die Zielinstanz und wurden deshalb lokal nicht ausgeführt. Der Docker-Job kann nach dem Merge per `workflow_dispatch` kontrolliert gestartet werden.

Fixes #86
